### PR TITLE
Add link to et-orbi, time with zone gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ none
 [Link to rails docs](http://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html)
 
 #### Alternatives
-none
+1. gem: et-orbi [link](https://github.com/floraison/et-orbi)
 
 ### ActiveSupport::CoreExtensions
 #### Integer


### PR DESCRIPTION
Thanks for the Hanami sticker you gave me during RubyKaigi 2017.

Here is a link to a library that combines Time and TimeZone.

Best regards.